### PR TITLE
git-pull fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Fixed
+- Handle parsing empty line ([#23](https://github.com/daizutabi/mkapi/pull/23)). Thanks to [tony](https://github.com/tony).
+
 
 ## [1.0.12] - 2020-07-29
 ### Changed

--- a/examples/google_style.py
+++ b/examples/google_style.py
@@ -79,7 +79,7 @@ class ExampleClass:
         """Returns a message list.
 
         Args:
-            n: Repeatation.
+            n: Repetition.
         """
         return [self.a] * n
 

--- a/examples/numpy_style.py
+++ b/examples/numpy_style.py
@@ -88,7 +88,7 @@ class ExampleClass:
         Parameters
         ----------
         n
-            Repeatation.
+            Repetition.
         """
         return [self.a] * n
 

--- a/mkapi/core/object.py
+++ b/mkapi/core/object.py
@@ -65,6 +65,9 @@ def get_fullname(obj: Any, name: str) -> str:
             return ""
         obj = getattr(obj, name)
 
+    if isinstance(obj, property):
+        return ""
+
     return ".".join(split_prefix_and_name(obj))
 
 

--- a/mkapi/core/postprocess.py
+++ b/mkapi/core/postprocess.py
@@ -11,7 +11,7 @@ def sourcelink(object: Object) -> str:
         link = f'<span id="{object.id}"></span>'
     else:
         link = ""
-    link += f'<a class="mkapi-src-link" href="../source/{object.module}'
+    link += f'<a class="mkapi-src-link" href="../source/{object.module}/'
     link += f'#{object.id}" title="Source for {object.id}">&lt;/&gt;</a>'
     return link
 

--- a/mkapi/templates/object.jinja2
+++ b/mkapi/templates/object.jinja2
@@ -11,7 +11,7 @@
   </div>
   {% if 'sourcelink' in filters or 'link' in filters or 'apilink' in filters -%}
   <div class="mkapi-src-link">
-    <a class="mkapi-src-link" href="../source/{{ object.module }}#{{ object.id }}" title="Source for {{ object.id }}">&lt;/&gt;</a>
+    <a class="mkapi-src-link" href="../source/{{ object.module }}/#{{ object.id }}" title="Source for {{ object.id }}">&lt;/&gt;</a>
   </div>
   {%- endif %}
 </div>

--- a/mkapi/utils.py
+++ b/mkapi/utils.py
@@ -12,6 +12,8 @@ def get_indent(line: str) -> int:
 
 
 def join(lines):
+    if not len(lines):
+        return ''
     indent = get_indent(lines[0])
     return "\n".join(line[indent:] for line in lines).strip()
 

--- a/setup.py
+++ b/setup.py
@@ -62,9 +62,9 @@ if sys.argv[-1] == "check":
 
 
 setup(
-    name="mkapi",
+    name="mkapi-git-pull",
     version=get_version("mkapi"),
-    description="An Auto API Documentation tool.",
+    description="Fork of mkapi since poetry fails with git + python verson constraint",
     long_description=long_description,
     url="https://mkapi.daizutabi.net",
     author="daizutabi",


### PR DESCRIPTION
To make it easier to see the diff / changes in the fork

Includes:

- Fix for links on CDNs to append slash in directories
- [ ] https://github.com/daizutabi/mkapi/pull/23 Fix for exception caused by numpy attributes without styling at end of docstring
- [x] https://github.com/daizutabi/mkapi/pull/24 Typo
- [x] https://github.com/daizutabi/mkapi/pull/27 Crash with property
 
   Note: after it gives this:

   ```
    WARNING -  Documentation file 'api/libvcs.util.md' contains a link to 'api/RepoLoggingAdapter.bin_name' which is not found in the documentation files.
    WARNING -  Documentation file 'api/libvcs.util.md' contains a link to 'api/RepoLoggingAdapter.name' which is not found in the documentation files.
   ```